### PR TITLE
Passing the wrong params to AddButton?

### DIFF
--- a/FCOCraftFilter/FCOCraftFilter.lua
+++ b/FCOCraftFilter/FCOCraftFilter.lua
@@ -2005,7 +2005,7 @@ local function FCOCraftFilter_PreHookButtonHandler(comingFrom, calledBy, isUnive
     --> if not ZO_CraftingUtils_IsCraftingWindowOpen() or if locVars.gLastCraftingType == nil then return end
     --local localizationVars = FCOCF.localizationVars.FCOCF_loc
 
-    local isPerfectPixelEnabled = (PerfectPixel ~= nil and true) or false
+    local isPerfectPixelEnabled = PP and PP.ADDON_NAME ~= nil
 
 
     --Disable the medium filters if the settings for the medium filter is disabled

--- a/FCOCraftFilter/FCOCraftFilter.lua
+++ b/FCOCraftFilter/FCOCraftFilter.lua
@@ -2126,14 +2126,14 @@ local function FCOCraftFilter_PreHookButtonHandler(comingFrom, calledBy, isUnive
         elseif comingFrom == LF_ENCHANTING_CREATION then
             local xOffset = (isPerfectPixelEnabled == false and -394) or -394
             --Hide the enchantment extraction button
-            AddButton(nil, zoVars.CRAFTSTATION_ENCHANTING_TABS:GetName() .. "ExtFCOCraftFilterHideBankButton", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,nil, nil, nil, nil, nil, true)
+            AddButton(nil, zoVars.CRAFTSTATION_ENCHANTING_TABS:GetName() .. "ExtFCOCraftFilterHideBankButton", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,nil, nil, nil, true)
             --Show the enchantment creation button
             addedButton = AddButton(zoVars.CRAFTSTATION_ENCHANTING_INVENTORY, zoVars.CRAFTSTATION_ENCHANTING_TABS:GetName() .. "CreationFCOCraftFilterHideBankButton", function(...) FCOCraftFilter_CraftingStationUpdateBankItemOption(LF_ENCHANTING_CREATION, true) end, nil, nil, tooltipVar, BOTTOM,  32, 32, xOffset, 35, BOTTOMLEFT, TOPLEFT, zoVars.CRAFTSTATION_ENCHANTING_TABS, false)
             --ENCHANTING EXTRACTION
         elseif comingFrom == LF_ENCHANTING_EXTRACTION then
             local xOffset = (isPerfectPixelEnabled == false and -505) or -505
             --Hide the enchantment creation button
-            AddButton(nil, zoVars.CRAFTSTATION_ENCHANTING_TABS:GetName() .. "CreationFCOCraftFilterHideBankButton", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,nil, nil, nil, nil, nil, true)
+            AddButton(nil, zoVars.CRAFTSTATION_ENCHANTING_TABS:GetName() .. "CreationFCOCraftFilterHideBankButton", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,nil, nil, nil, true)
             --Show the enchantment extraction button
             addedButton = AddButton(zoVars.CRAFTSTATION_ENCHANTING_INVENTORY, zoVars.CRAFTSTATION_ENCHANTING_TABS:GetName() .. "ExtFCOCraftFilterHideBankButton", function(...) FCOCraftFilter_CraftingStationUpdateBankItemOption(LF_ENCHANTING_EXTRACTION, true) end, nil, nil, tooltipVar, BOTTOM,  32, 32, xOffset, 35, BOTTOMLEFT, TOPLEFT, zoVars.CRAFTSTATION_ENCHANTING_TABS, false)
         --TRANSMUTATION / RETRAIT

--- a/FCOCraftFilter/FCOCraftFilter.lua
+++ b/FCOCraftFilter/FCOCraftFilter.lua
@@ -52,6 +52,8 @@ local libFilters_IsUniversalDeconstructionPanelShown
 local libFilters_getUniversalDeconstructionPanelActiveTabFilterType
 local LCM
 
+local isPerfectPixelEnabled = PP and PP.ADDON_NAME ~= nil
+
 local tos = tostring
 
 --local APIVersion = GetAPIVersion()
@@ -1741,7 +1743,7 @@ local function addFilterButtonUniversalDecon(filterType)
     local universalDeconFilterButtons = FCOCF.filterButtons[FCOCF_CRAFTINGTYPE_UNIVERSAL_DECONSTRUCTION]
 
     --Compatibility for addon PerfectPixel
-    local xOffset = (PerfectPixel == nil and -380) or -355
+    local xOffset = (isPerfectPixelEnabled == nil and -380) or -355
 
     --UniversalDeconstruction
     --DECONSTRUCTION & Jewelry deconstructin (re-use the same button, just updates the filterType!)
@@ -1845,7 +1847,7 @@ local function updateRetraitButtons(craftSkill)
     FCOCF.locVars.gLastCraftingType = craftSkill
     --Add the button to the retrait station now
     local tooltipVar = ""
-    local xOffset = (PerfectPixel == nil and -445) or -425
+    local xOffset = (isPerfectPixelEnabled == nil and -445) or -425
     AddButton(zoVars.TRANSMUTATIONSTATION_INVENTORY, zoVars.TRANSMUTATIONSTATION_TABS:GetName() .. "RetraitFCOCraftFilterHideBankButton", function(...) FCOCraftFilter_CraftingStationUpdateBankItemOption(LF_RETRAIT, true) end, nil, nil, tooltipVar, BOTTOM, 32, 32, xOffset, 35, BOTTOMLEFT, TOPLEFT, zoVars.TRANSMUTATIONSTATION_TABS, false)
     --Update the filters for the Retrait station now (again)
     FCOCraftFilter_CraftingStationUpdateBankItemOption(LF_RETRAIT, false)
@@ -2004,9 +2006,6 @@ local function FCOCraftFilter_PreHookButtonHandler(comingFrom, calledBy, isUnive
     --Implement some checks here in order to abort further handling if not at a crafting station.
     --> if not ZO_CraftingUtils_IsCraftingWindowOpen() or if locVars.gLastCraftingType == nil then return end
     --local localizationVars = FCOCF.localizationVars.FCOCF_loc
-
-    local isPerfectPixelEnabled = PP and PP.ADDON_NAME ~= nil
-
 
     --Disable the medium filters if the settings for the medium filter is disabled
     if not settings.enableMediumFilters then


### PR DESCRIPTION
Possible fix for this error.
```
user:/AddOns/FCOCraftFilter/FCOCraftFilter.lua:765: attempt to index a nil value
stack traceback:
user:/AddOns/FCOCraftFilter/FCOCraftFilter.lua:765: in function 'getCurrentButtonStateAndTexture'
|caaaaaa<Locals> isUniversalDecon = F, isResearchShowOnlyCurrentlyResearched = F, settings = [table:1]{}, localizationVars = [table:2]{button_FCO_currently_show_only_craftbag_tooltip = "Aktuell: Only showing Craftbag...", options_multisets_create_enable_favorite_TT = "Enable this favorite category ...", options_enable_medium_filter = "Enable 'show only bank' filter...", options_language_tooltip = "Choose the language", options_multisets_create_fav_99006 = "Hybrid DD", button_FCO_currently_hide_craftbag_tooltip = "Aktuell: Hiding Craftbag items...", options_enable_button_only_currently_researched_tooltip = "Show a filter button at the re...", options_multisets_create_fav_99001 = "Tank", options_language = "Language", options_savedvariables_tooltip = "Save the addon settings for al...", options_language_dropdown_selection2 = "German", options_enable_only_worn_filter_TT = "Enable another filter where yo...", button_FCO_show_only_craftbag_tooltip = "Next: Only show Craftbag items...", options_description = "FCO CraftFilter - filter your ...", button_FCO_hide_bank_tooltip = "Next: Hide bank items", options_savedvariables = "Save settings", options_defaultCraftTab_enable_TT = "Enable the default crafting ta...", options_language_use_client_tooltip = "Always let the addon use the g...", options_header_grandmaster_crafting = "Grand Master Crafting stations...", options_language_use_client = "Use client language", options_language_dropdown_selection6 = "Japanese", options_language_description1 = "CAUTION: Changing the language...", button_FCO_hide_craftbag_tooltip = "Next: Hide Craftbag items", options_header1 = "General settings", button_FCO_currently_show_all_tooltip = "Currently: Showing all items", options_language_dropdown_selection4 = "Spanish", button_FCO_currently_show_only_worn_tooltip = "Currently: Only showing worn i...", options_multisets_create_fav_tooltip = "The favorite name shown at the...", button_FCO_currently_hide_bank_tooltip = "Currently: Hiding bank items", options_multisets_create_enable_favorite = "Enable favorite category", options_savedVariables_dropdown_selection1 = "Each character", button_FCO_show_only_bank_tooltip = "Next: Only show bank items", button_FCO_show_all_tooltip = "Next: Show all items", options_header_crafting_stations = "Crafting stations", options_show_only_worn_at_only_invetory_TT = "Show currently worn items at t...", options_show_only_worn_at_only_invetory = "Include 'Worn' at 'Only invent...", button_FCO_show_only_worn_tooltip = "Next: Show only worn items", options_language_dropdown_selection1 = "English", options_enable_only_worn_filter = "Enable 'show only worn' filter...", button_FCO_currently_show_only_bank_tooltip = "Currently: Only showing bank i...", options_multisets_create_fav_99002 = "Stam Heal", options_multisets_create_enable_favorites = "Enable Grand Master Crafting S...", options_multisets_create_fav_99003 = "Mag Heal", options_multisets_create_fav_99005 = "Mag DD", options_savedVariables_dropdown_selection2 = "Account wide", options_multisets_create_fav_99004 = "Stam DD", options_defaultCraftTab_enable = "Enable default crafing tab", options_enable_medium_filter_tooltip = "Enable a third filter where yo...", options_language_dropdown_selection3 = "French", options_header_defaultCraftTab = "Default crafting tab"}, locVars = [table:3]{preChatTextGreen = "|c22DD22FCO CraftFilter|r ", preChatText = "FCO CraftFilter", gLastPanel = 14, preChatTextBlue = "|c2222DDFCO CraftFilter|r ", preChatTextRed = "|cDD2222FCO CraftFilter|r "}, lastPanel = 14, isRefinementPanel = T </Locals>|r
user:/AddOns/FCOCraftFilter/FCOCraftFilter.lua:1575: in function 'AddButton'
|caaaaaa<Locals> parent = ud, name = "ZO_SmithingTopLevelRefinementP...", callbackFunction = user:/AddOns/FCOCraftFilter/FCOCraftFilter.lua:2094, tooltipText = "", tooltipAlign = 4, width = 32, height = 32, left = -500, top = 35, alignMain = 6, alignBackup = 3, alignControl = ud, hideButton = F, isUniversalDecon = F, isResearchShowOnlyCurrentlyResearched = F, locVars = [table:3], colorizeTextureAccordingToFilterApplied = user:/AddOns/FCOCraftFilter/FCOCraftFilter.lua:1478, updateButtonTextureAndTooltip = user:/AddOns/FCOCraftFilter/FCOCraftFilter.lua:1497, button = ud, texture = ud </Locals>|r
user:/AddOns/FCOCraftFilter/FCOCraftFilter.lua:2094: in function 'FCOCraftFilter_PreHookButtonHandler'
|caaaaaa<Locals> comingFrom = 14, calledBy = "SMITHING refine SetMode", isUniversalDeconShown = F, settings = [table:1], locVars = [table:3], isPerfectPixelEnabled = T, tooltipVar = "", tooltipVarCurrentlyResearched = "", lastPanel = 14, xExtra = 0, xOffset = -500 </Locals>|r
user:/AddOns/FCOCraftFilter/FCOCraftFilter.lua:2532: in function 'func'
EsoUI/Libraries/Globals/globalapi.lua:271: in function '(anonymous)'
```